### PR TITLE
Fix typo - torch.cuda.is_available()

### DIFF
--- a/CV_REmodel.py
+++ b/CV_REmodel.py
@@ -47,7 +47,7 @@ seed = 42
 torch.manual_seed(seed)
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 # seed gpus if available
-if torch.cuda.isavalable():
+if torch.cuda.is_available():
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 print(device)

--- a/TransformerClassifier_REmbedding.ipynb
+++ b/TransformerClassifier_REmbedding.ipynb
@@ -1464,7 +1464,7 @@
     "torch.manual_seed(seed)\n",
     "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "# seed gpus if available\n",
-    "if torch.cuda.isavalable():\n",
+    "if torch.cuda.is_avalable():\n",
     "    torch.cuda.manual_seed(seed)\n",
     "    torch.cuda.manual_seed_all(seed)\n",
     "\n",

--- a/TransformerClassifier_REmbedding.ipynb
+++ b/TransformerClassifier_REmbedding.ipynb
@@ -1464,7 +1464,7 @@
     "torch.manual_seed(seed)\n",
     "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
     "# seed gpus if available\n",
-    "if torch.cuda.is_avalable():\n",
+    "if torch.cuda.is_available():\n",
     "    torch.cuda.manual_seed(seed)\n",
     "    torch.cuda.manual_seed_all(seed)\n",
     "\n",

--- a/trainREmodel.py
+++ b/trainREmodel.py
@@ -44,7 +44,7 @@ seed = 42
 torch.manual_seed(seed)
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 # seed gpus if available
-if torch.cuda.isavalable():
+if torch.cuda.is_available():
     torch.cuda.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 print(device)


### PR DESCRIPTION
Hi guys, we are reading your great piece of work and trying to run the code ourselves and found that you've made some typos in code - it should be `torch.cuda.is_available()` to determine whether CUDA is available. Could you please review our PR and merge it if it looks good to you? 

Thanks.

Melinna Mei from PolyU & Fei Song (Melinna's husband)
